### PR TITLE
fix vite path-name

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,16 @@ Professional circuit editor with a modern UI, SVG/LaTeX export, and asynchronous
 
 ## 1) Web
 
+macOS/Linux:
+
 ```bash
+npm install
+npm run dev
+```
+
+Windows CMD:
+
+```bat
 npm install
 npm run dev
 ```
@@ -65,13 +74,32 @@ Default dev URL: `http://127.0.0.1:5173`
 
 ## 2) API
 
+macOS/Linux (Unix):
+
 ```bash
 cd api
 python3 -m venv .venv
 source .venv/bin/activate
-pip install -r requirements.txt
-uvicorn app.main:app --reload --port 8000
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+python -m uvicorn app.main:app --reload --port 8000
 ```
+
+Windows CMD:
+
+```bat
+cd api
+py -m venv .venv
+.venv\Scripts\activate.bat
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+python -m uvicorn app.main:app --reload --port 8000
+```
+
+Note:
+- Avvio corretto API: `python -m uvicorn app.main:app --reload --port 8000`
+- Non usare `python app/main.py`.
+- Per uscire dalla virtualenv: `deactivate`
 
 Health check:
 

--- a/api/README.md
+++ b/api/README.md
@@ -14,17 +14,30 @@ FastAPI service for asynchronous circuit analysis (nodal and mesh workflows), co
 
 1. Create a virtual environment and install dependencies:
 
+macOS/Linux (Unix):
+
 ```bash
 cd api
 python3 -m venv .venv
 source .venv/bin/activate
-pip install -r requirements.txt
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+```
+
+Windows CMD:
+
+```bat
+cd api
+py -m venv .venv
+.venv\Scripts\activate.bat
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
 ```
 
 2. Start the API:
 
 ```bash
-uvicorn app.main:app --reload --port 8000
+python -m uvicorn app.main:app --reload --port 8000
 ```
 
 3. Verify health:
@@ -32,6 +45,15 @@ uvicorn app.main:app --reload --port 8000
 ```bash
 curl http://127.0.0.1:8000/health
 ```
+
+Notes:
+- Start the service with `uvicorn`, not with `python app/main.py`.
+- Exit virtualenv with `deactivate`.
+
+Troubleshooting:
+- `ModuleNotFoundError: No module named 'fastapi'`
+  - activate `.venv`
+  - run `python -m pip install -r requirements.txt`
 
 ## Endpoints
 

--- a/config/vite.config.ts
+++ b/config/vite.config.ts
@@ -1,15 +1,15 @@
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  root: new URL("../web", import.meta.url).pathname,
+  root: "web",
   build: {
     outDir: "../dist",
     emptyOutDir: true,
     rollupOptions: {
       input: {
-        landing: new URL("../web/index.html", import.meta.url).pathname,
-        editor: new URL("../web/pages/editor.html", import.meta.url).pathname,
-        analysis: new URL("../web/pages/analysis.html", import.meta.url).pathname,
+        landing: "index.html",
+        editor: "pages/editor.html",
+        analysis: "pages/analysis.html",
       },
     },
   },

--- a/config/vite.config.ts
+++ b/config/vite.config.ts
@@ -7,9 +7,9 @@ export default defineConfig({
     emptyOutDir: true,
     rollupOptions: {
       input: {
-        landing: "index.html",
-        editor: "pages/editor.html",
-        analysis: "pages/analysis.html",
+        landing: "/index.html",
+        editor: "/pages/editor.html",
+        analysis: "/pages/analysis.html",
       },
     },
   },

--- a/web/src/analysis/analysisApi.ts
+++ b/web/src/analysis/analysisApi.ts
@@ -12,7 +12,7 @@ import type {
 // Allow runtime override from embedding pages/tests; fallback to local backend.
 const API_BASE = (window as Window & { __analysisApiBase?: string }).__analysisApiBase ?? "http://127.0.0.1:8000/api/v1";
 
-/** Fetch current status for a queued/running/completed job. */
+/** Fetch current status for a queued/running/completed job.  */
 export async function getJobStatus(jobId: string): Promise<AnalysisJobStatusResponse> {
   const res = await fetch(`${API_BASE}/analysis/jobs/${jobId}`, { cache: "no-store" });
   if (!res.ok) throw new Error(`Status request failed: ${res.status}`);


### PR DESCRIPTION
Using `new URL(...).pathname` in Vite config could produce invalid normalized paths on Windows (e.g. `C:\C:\...`), causing `vite dev` failures.
Changes:
- Set `root` to a Vite-relative path: `"web"`.
- Replaced URL/pathname-based page inputs with root-relative inputs:
  - `index.html`
  - `pages/editor.html`
  - `pages/analysis.html`
 Impact
- No functional behavior changes in app pages/routes.
- Dev server and build config are more stable on Windows.
